### PR TITLE
Section 8.6: s/map/maps?

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2686,7 +2686,7 @@ except for the following parameters:
   - d = -39081
 - f: Twisted Edwards Elligator 2 method ({{ell2edwards}})
 - M: curve448, defined in {{!RFC7748, Section 4.2}}
-- rational\_map: the 4-isogeny map defined in {{!RFC7748, Section 4.2}}
+- rational\_map: the 4-isogeny maps defined in {{!RFC7748, Section 4.2}}
 
 curve448\_XOF:SHAKE256\_ELL2\_NU\_ is identical to curve448\_XOF:SHAKE256\_ELL2\_RO\_,
 except that the encoding type is encode\_to\_curve ({{roadmap}}).


### PR DESCRIPTION
Per Section 4.2 of RFC 7748, we suggest changing
"map" to "maps" here.  Please let us know if this is incorrect (e.g., was "one of the 4-isogeny maps" intended?).

Original:
 *  rational_map: the 4-isogeny map defined in [RFC7748], Section 4.2