### PR TITLE
Section 10.6: step 10

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3054,7 +3054,7 @@ of the counter byte I2OSP(i, 1)).
 
 The essential difference between the construction discussed in {{CDMP05}} and
 expand\_message\_xmd is that the latter hashes a counter appended to
-strxor(b\_0, b\_(i - 1)) (Section 5.3.1, step 10) rather than to b\_0.
+strxor(b\_0, b\_(i - 1)) ({#hashtofield-expand-xmd}, step 10) rather than to b\_0.
 This approach increases the Hamming distance between inputs to different
 invocations of H, which reduces the likelihood that nonidealities in H
 affect the distribution of the b\_i values.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3054,7 +3054,7 @@ of the counter byte I2OSP(i, 1)).
 
 The essential difference between the construction discussed in {{CDMP05}} and
 expand\_message\_xmd is that the latter hashes a counter appended to
-strxor(b\_0, b\_(i - 1)) (step 10) rather than to b\_0.
+strxor(b\_0, b\_(i - 1)) (Section 5.3.1, step 10) rather than to b\_0.
 This approach increases the Hamming distance between inputs to different
 invocations of H, which reduces the likelihood that nonidealities in H
 affect the distribution of the b\_i values.


### PR DESCRIPTION
Section 10.6:  For ease of the reader, may we change "(step 10)" to "(Section 5.3.1, step 10)" here (along the lines of "(Section 5.3.1, step 4)" in the text of Section 10.7, method 3)?

Original:
 The essential difference between the construction of [CDMP05] and
 expand_message_xmd is that the latter hashes a counter appended to
 strxor(b_0, b_(i - 1)) (step 10) rather than to b_0.