### PR TITLE
Appendix F.2.1: s/subroutines/subroutine

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3846,7 +3846,7 @@ Steps:
 26. return (x, y)
 ~~~
 
-### sqrt_ratio Subroutines {#straightline-sswu-sqrt-ratio}
+### sqrt_ratio Subroutine {#straightline-sswu-sqrt-ratio}
 
 This section defines three variants of the sqrt_ratio subroutine used by the
 above procedure.


### PR DESCRIPTION
Appendix F.2.1:  Because the singular form
"sqrt_ratio subroutine" is mentioned in Appendix F.2 and in this section, may we change "subroutines" to "subroutine"